### PR TITLE
SCOTCH_PATH updates for RDHPCS machines

### DIFF
--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -149,6 +149,10 @@ EOF
   if [ ! -z $basemodmpi ]; then
     echo "  module load $basemodmpi"                        >> matrix.head
   fi
+  if [ ! -z $gnumodfiles ]; then
+    echo "  module use  $gnumodfiles"                       >> matrix.head
+  fi
+  echo "  module load $modgnu"                              >> matrix.head
   echo "  module use  $hpcstackpath"                        >> matrix.head
   echo "  module load $hpcstackversion"                     >> matrix.head
   echo "  module load $modcomp"                             >> matrix.head
@@ -162,11 +166,7 @@ EOF
   echo "  module load $modg2"                               >> matrix.head
   echo "  module load $modw3emc"                            >> matrix.head
   echo "  module load $modesmf"                             >> matrix.head
-  if [ ! -z $gnumodfiles ]; then
-    echo "  module use  $gnumodfiles"                       >> matrix.head
-  fi
-  echo "  module load $modgnu"                              >> matrix.head
-  echo " "
+
   echo "  export METIS_PATH=${metispath}"                   >> matrix.head
   echo "  export SCOTCH_PATH=${scotchpath}"                 >> matrix.head
   echo "  export path_build_root=$(dirname $main_dir)/regtests/buildmatrix" >> matrix.head

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -149,10 +149,6 @@ EOF
   if [ ! -z $basemodmpi ]; then
     echo "  module load $basemodmpi"                        >> matrix.head
   fi
-  if [ ! -z $gnumodfiles ]; then
-    echo "  module use  $gnumodfiles"                       >> matrix.head
-  fi
-  echo "  module load $modgnu"                              >> matrix.head
   echo "  module use  $hpcstackpath"                        >> matrix.head
   echo "  module load $hpcstackversion"                     >> matrix.head
   echo "  module load $modcomp"                             >> matrix.head
@@ -166,6 +162,10 @@ EOF
   echo "  module load $modg2"                               >> matrix.head
   echo "  module load $modw3emc"                            >> matrix.head
   echo "  module load $modesmf"                             >> matrix.head
+  if [ ! -z $gnumodfiles ]; then
+    echo "  module use  $gnumodfiles"                       >> matrix.head
+  fi
+  echo "  module load $modgnu"                              >> matrix.head
 
   echo "  export METIS_PATH=${metispath}"                   >> matrix.head
   echo "  export SCOTCH_PATH=${scotchpath}"                 >> matrix.head

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -66,7 +66,7 @@ EOF
     basemodmpi='impi/2022.1.2'
     modcomp='hpc-intel/2022.1.2'
     modmpi='hpc-impi/2022.1.2'
-    scotchpath='/scratch2/STI/coastal/save/Ali.Abdolali/hpc-stack/scotch/install'
+    scotchpath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
     metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
     modcmake='cmake/3.20.1'
   elif [ $isorion ]

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -76,7 +76,7 @@ EOF
     hpcstackversion='hpc/1.2.0'
     modcomp='hpc-intel/2022.1.2'
     modmpi='hpc-impi/2022.1.2'
-    scotchpath='/work/noaa/marine/ali.abdolali/Source/hpc-stack/scotch/install'
+    scotchpath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
     metispath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
     modcmake='cmake/3.22.1'
   else

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -60,10 +60,10 @@ EOF
   then
     # If no other h, assuming Hera
     batchq='slurm'
-    hpcstackpath='/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack'
-    hpcstackversion='hpc/1.2.0'
     basemodcomp='intel/2022.1.2'
     basemodmpi='impi/2022.1.2'
+    hpcstackpath='/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack'
+    hpcstackversion='hpc/1.2.0'
     modcomp='hpc-intel/2022.1.2'
     modmpi='hpc-impi/2022.1.2'
     scotchpath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
@@ -72,6 +72,8 @@ EOF
   elif [ $isorion ]
   then
     batchq='slurm'
+    basemodcomp='intel/2022.1.2'
+    basemodmpi='impi/2022.1.2'
     hpcstackpath='/work/noaa/epic-ps/hpc-stack/libs/intel/2022.1.2/modulefiles/stack'
     hpcstackversion='hpc/1.2.0'
     modcomp='hpc-intel/2022.1.2'

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -69,7 +69,6 @@ EOF
     scotchpath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
     metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
     modcmake='cmake/3.20.1'
-    modgnu='gnu/9.2.0'
   elif [ $isorion ]
   then
     batchq='slurm'
@@ -82,8 +81,6 @@ EOF
     scotchpath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
     metispath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
     modcmake='cmake/3.22.1'
-    modgnu='gcc/10.2.0'
-    gnumodfiles='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/scotch-v7.0.3/modulefiles'
   else
     batchq=
   fi
@@ -162,10 +159,6 @@ EOF
   echo "  module load $modg2"                               >> matrix.head
   echo "  module load $modw3emc"                            >> matrix.head
   echo "  module load $modesmf"                             >> matrix.head
-  if [ ! -z $gnumodfiles ]; then
-    echo "  module use  $gnumodfiles"                       >> matrix.head
-  fi
-  echo "  module load $modgnu"                              >> matrix.head
 
   echo "  export METIS_PATH=${metispath}"                   >> matrix.head
   echo "  export SCOTCH_PATH=${scotchpath}"                 >> matrix.head

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -107,6 +107,7 @@ EOF
     echo '#SBATCH -o matrix.out'                            >> matrix.head
     echo '#SBATCH -p orion'                                 >> matrix.head
     echo '#SBATCH --exclusive'                              >> matrix.head
+    echo ' '                                                >> matrix.head
     echo 'ulimit -s unlimited'                              >> matrix.head
     echo 'ulimit -c 0'                                      >> matrix.head
     echo 'export KMP_STACKSIZE=2G'                          >> matrix.head
@@ -137,21 +138,21 @@ EOF
 # Netcdf, Parmetis and SCOTCH modules & variables
   echo "  module purge"                                     >> matrix.head
   echo "  module load $modcmake"                            >> matrix.head
-  echo "  module use $hpcstackpath"                         >> matrix.head
-  echo "  module load $hpcstackversion"                     >> matrix.head
   if [ ! -z $basemodcomp ]; then
     echo "  module load $basemodcomp"                       >> matrix.head
   fi
   if [ ! -z $basemodmpi ]; then
     echo "  module load $basemodmpi"                        >> matrix.head
   fi
+  echo "  module use  $hpcstackpath"                        >> matrix.head
+  echo "  module load $hpcstackversion"                     >> matrix.head
   echo "  module load $modcomp"                             >> matrix.head
   echo "  module load $modmpi"                              >> matrix.head
-  echo "  module load $modnetcdf"                           >> matrix.head
-  echo "  module load $modjasper"                           >> matrix.head
-  echo "  module load $modzlib"                             >> matrix.head
   echo "  module load $modpng"                              >> matrix.head
+  echo "  module load $modzlib"                             >> matrix.head
+  echo "  module load $modjasper"                           >> matrix.head
   echo "  module load $modhdf5"                             >> matrix.head
+  echo "  module load $modnetcdf"                           >> matrix.head
   echo "  module load $modbacio"                            >> matrix.head
   echo "  module load $modg2"                               >> matrix.head
   echo "  module load $modw3emc"                            >> matrix.head

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -69,6 +69,7 @@ EOF
     scotchpath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
     metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
     modcmake='cmake/3.20.1'
+    modgnu='gnu/9.2.0'
   elif [ $isorion ]
   then
     batchq='slurm'
@@ -81,6 +82,8 @@ EOF
     scotchpath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
     metispath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
     modcmake='cmake/3.22.1'
+    modgnu='gcc/10.2.0'
+    gnumodfiles='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/scotch-v7.0.3/modulefiles'
   else
     batchq=
   fi
@@ -159,9 +162,13 @@ EOF
   echo "  module load $modg2"                               >> matrix.head
   echo "  module load $modw3emc"                            >> matrix.head
   echo "  module load $modesmf"                             >> matrix.head
-
+  if [ ! -z $gnumodfiles ]; then
+    echo "  module use  $gnumodfiles"                       >> matrix.head
+  fi
+  echo "  module load $modgnu"                              >> matrix.head
+  echo " "
   echo "  export METIS_PATH=${metispath}"                   >> matrix.head
-  echo "  export SCOTCH_PATH=${scotchpath}"                   >> matrix.head
+  echo "  export SCOTCH_PATH=${scotchpath}"                 >> matrix.head
   echo "  export path_build_root=$(dirname $main_dir)/regtests/buildmatrix" >> matrix.head
   echo '  [[ -d ${path_build_root} ]] && rm -rf ${path_build_root}'         >> matrix.head
   echo ' '


### PR DESCRIPTION
# Pull Request Summary
Adds `SCOTCH_PATH` in WW3 code mgr disc space.

## Description
Provide a detailed description of what this PR does.
  * This PR adds paths for new SCOTCH builds on the WW3 code mgr account for both `hera` and `orion`
What bug does it fix, or what feature does it add?
  * Adds new path for SCOTCH domain decomposition.
Is a change of answers expected from this PR?
  * For unstructured application changes are to be expected as we are switching from the Parmetis library to the SCOTCH library for domain decomposition.  Applications NOT using these libraries will be unaffected.

Please also include the following information: 
 
* Mention any labels that should be added: 
  * NA.
* Are answer changes expected from this PR? 
  * No. 
* Co-authors
  * @JessicaMeixner-NOAA @aerorahul

### Issue(s) addressed
- fixes #885

### Commit Message
SCOTCH_PATH updates for RDHPCS machines

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 

### Testing

* How were these changes tested?
  * Two identical matrix regression tests were run on each `orion` and `hera`.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * SCOTCH has been added.  Existing unstructured tests that had used Parmetis now use SCOTCH, so the new SCOTCH library is now tested using the existing tests.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  `hera/intel`, `orion/intel`. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * Two identical runs using SCOTCH were compared against each other using matrix.comp.  As it is a different decomposition library, we could expect changes going from Parmetis to SCOTCH, so this was not a comparison performed.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * In both the `orion` and `hera` output's there were a large number of `(0 files differ)` which turned out to be detecting linked files from the regtest `input/` directory to the `work*/` directories.  For this reason and the ongoing `mod_def` issue for unstructured, I added some annotation to the Summary output (for orion.  it is the same for the same files on hera).

**orion**
```
**********************************************************************                 
********************* non-identical cases ****************************                 
**********************************************************************                 
                                                                                       
1) (0 files differ): due to file (track_i.outer) linked from input/ to work/           
--                                                                                     
mww3_test_02/./work_PR1_c                     (0 files differ)                         
mww3_test_02/./work_PR3_UNO_d_c                     (0 files differ)                   
mww3_test_02/./work_PR3_UNO_b                     (0 files differ)                     
mww3_test_02/./work_PR2_UQ_d                     (0 files differ)                      
mww3_test_02/./work_PR3_UQ_d                     (0 files differ)                      
mww3_test_02/./work_PR2_UQ_a                     (0 files differ)                      
mww3_test_02/./work_PR1_d                     (0 files differ)                         
mww3_test_02/./work_PR2_UQ_c                     (0 files differ)                      
mww3_test_02/./work_PR3_UQ_MPI_c_c                     (0 files differ)                
mww3_test_02/./work_PR2_UNO_MPI_b                     (0 files differ)                 
mww3_test_02/./work_PR2_UQ_MPI_b                     (0 files differ)                  
mww3_test_02/./work_PR1_a                     (0 files differ)                         
mww3_test_02/./work_PR2_UNO_c                     (0 files differ)                     
mww3_test_02/./work_PR3_UNO_a                     (0 files differ)                     
mww3_test_02/./work_PR3_UNO_MPI_a_c                     (0 files differ)               
mww3_test_02/./work_PR1_MPI_c                     (0 files differ)                     
mww3_test_02/./work_PR3_UNO_d                     (0 files differ)                     
mww3_test_02/./work_PR3_UNO_c                     (0 files differ)                     
mww3_test_02/./work_PR3_UQ_a_c                     (0 files differ)                    
mww3_test_02/./work_PR2_UNO_d                     (0 files differ)                     
mww3_test_02/./work_PR2_UNO_MPI_d                     (0 files differ)                 
mww3_test_02/./work_PR3_UQ_c_c                     (0 files differ)                    
mww3_test_02/./work_PR3_UNO_MPI_c                     (0 files differ)                 
mww3_test_02/./work_PR3_UNO_MPI_b                     (0 files differ)                 
mww3_test_02/./work_PR2_UNO_MPI_a                     (0 files differ)                 
mww3_test_02/./work_PR3_UNO_b_c                     (0 files differ)                   
mww3_test_02/./work_PR3_UNO_MPI_d_c                     (0 files differ)               
mww3_test_02/./work_PR3_UQ_d_c                     (0 files differ)                    
mww3_test_02/./work_PR3_UQ_MPI_a_c                     (0 files differ)                
mww3_test_02/./work_PR1_MPI_b                     (0 files differ)                     
mww3_test_02/./work_PR3_UQ_MPI_b                     (0 files differ)                  
mww3_test_02/./work_PR2_UQ_MPI_c                     (0 files differ)                  
mww3_test_02/./work_PR3_UNO_a_c                     (0 files differ)                   
mww3_test_02/./work_PR3_UNO_MPI_b_c                     (0 files differ)               
mww3_test_02/./work_PR1_b                     (0 files differ)                         
mww3_test_02/./work_PR3_UQ_a                     (0 files differ)                      
mww3_test_02/./work_PR3_UNO_c_c                     (0 files differ)                   
mww3_test_02/./work_PR3_UQ_MPI_d_c                     (0 files differ)                
mww3_test_02/./work_PR3_UNO_MPI_d                     (0 files differ)                 
mww3_test_02/./work_PR2_UNO_a                     (0 files differ)                     
mww3_test_02/./work_PR2_UQ_MPI_d                     (0 files differ)                  
mww3_test_02/./work_PR3_UQ_b_c                     (0 files differ)                    
mww3_test_02/./work_PR3_UQ_MPI_b_c                     (0 files differ)                
mww3_test_02/./work_PR2_UQ_MPI_a                     (0 files differ)                  
mww3_test_02/./work_PR2_UNO_b                     (0 files differ)                     
mww3_test_02/./work_PR3_UNO_MPI_c_c                     (0 files differ)               
mww3_test_02/./work_PR2_UNO_MPI_c                     (0 files differ)                 
mww3_test_02/./work_PR3_UQ_MPI_c                     (0 files differ)                  
mww3_test_02/./work_PR3_UQ_MPI_d                     (0 files differ)                  
mww3_test_02/./work_PR3_UQ_b                     (0 files differ)                      
mww3_test_02/./work_PR3_UNO_MPI_a                     (0 files differ)                 
mww3_test_02/./work_PR1_MPI_d                     (0 files differ)                     
mww3_test_02/./work_PR2_UQ_b                     (0 files differ)                      
mww3_test_02/./work_PR1_MPI_a                     (0 files differ)                     
mww3_test_02/./work_PR3_UQ_MPI_a                     (0 files differ)                  
mww3_test_02/./work_PR3_UQ_c                     (0 files differ)                      
--                                                                                     
                                                                                       
-- 2) usual non-b4b                                                                    
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)                
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)                 
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)              
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)                
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)               
mww3_test_03/./work_PR2_UNO_MPI_d2                     (17 files differ)               
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)                 
mww3_test_03/./work_PR1_MPI_d2                     (11 files differ)                   
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)             
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)                  
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)                
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)                        
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)                        
ww3_ufs1.3/./work_a                     (3 files differ)                               
--                                                                                     
                                                                                       
3) (0 files differ): due to file (anl.grbtxt) linked from input/ to work/              
--                                                                                     
ww3_ta1/./work_UPD2_U_cap                     (0 files differ)                         
ww3_ta1/./work_UPD6_O                     (0 files differ)                             
ww3_ta1/./work_UPD0F_U                     (0 files differ)                            
ww3_ta1/./work_UPD5_U                     (0 files differ)                             
ww3_ta1/./work_UPD2_U                     (0 files differ)                             
ww3_ta1/./work_UPD2_O                     (0 files differ)                             
ww3_ta1/./work_UPD3_U_cap                     (0 files differ)                         
ww3_ta1/./work_UPD3_U                     (0 files differ)                             
ww3_ta1/./work_UPD0F_O                     (0 files differ)                            
ww3_ta1/./work_UPD6_U_cap                     (0 files differ)                         
ww3_ta1/./work_UPD6_U                     (0 files differ)                             
ww3_ta1/./work_UPD5_O                     (0 files differ)                             
ww3_ta1/./work_UPD5_U_cap                     (0 files differ)                         
ww3_ta1/./work_UPD3_O                     (0 files differ)                             
--                                                                                     
                                                                                       
4) (1 file differ): due to 'APPLE partioning' string in file OUTPUT_TOY.txt            
--                                                                                     
ww3_tp2.14/./work_OASACM6                     (1 files differ)                         
--                                                                                     
                                                                                       
5) (1 file differ): due to unstructured mod_def's                                      
--                                                                                     
ww3_tp2.17/./work_mc1                     (1 files differ)                             
ww3_tp2.17/./work_ma                     (1 files differ)                              
ww3_tp2.17/./work_mc                     (1 files differ)                              
ww3_tp2.17/./work_mb                     (1 files differ)                              
ww3_tp2.17/./work_b                     (1 files differ)                               
ww3_tp2.17/./work_c                     (1 files differ)                               
ww3_tp2.17/./work_a                     (1 files differ)                               
ww3_tp2.17/./work_ma1                     (1 files differ)                             
ww3_tp2.6/./work_ST4                     (1 files differ)                              
ww3_tp2.6/./work_pdlib                     (1 files differ)                            
ww3_tp2.6/./work_ST0                     (1 files differ)                              
ww3_ts4/./work_ug_MPI                     (1 files differ)                             
--                                                                                                                                                             
**********************************************************************                 
************************ identical cases *****************************                 
********************************************************************** 
```
* [orion.matrixCompFull.txt](https://github.com/erdc/WW3/files/10844625/orion.matrixCompFull.txt)
* [orion.matrixDiff.txt](https://github.com/erdc/WW3/files/10844626/orion.matrixDiff.txt)
* [orion.matrixCompSummary.txt](https://github.com/erdc/WW3/files/10844627/orion.matrixCompSummary.txt)



**hera**
```
**********************************************************************       
********************* non-identical cases ****************************       
**********************************************************************       
mww3_test_02/./work_PR1_c                     (0 files differ)               
mww3_test_02/./work_PR2_UNO_c                     (0 files differ)           
mww3_test_02/./work_PR3_UQ_MPI_a                     (0 files differ)        
mww3_test_02/./work_PR1_MPI_d                     (0 files differ)           
mww3_test_02/./work_PR3_UNO_MPI_b_c                     (0 files differ)     
mww3_test_02/./work_PR3_UNO_c_c                     (0 files differ)         
mww3_test_02/./work_PR3_UQ_MPI_c                     (0 files differ)        
mww3_test_02/./work_PR2_UNO_MPI_d                     (0 files differ)       
mww3_test_02/./work_PR2_UNO_d                     (0 files differ)           
mww3_test_02/./work_PR2_UQ_MPI_a                     (0 files differ)        
mww3_test_02/./work_PR3_UQ_MPI_a_c                     (0 files differ)      
mww3_test_02/./work_PR3_UNO_MPI_d_c                     (0 files differ)     
mww3_test_02/./work_PR1_d                     (0 files differ)               
mww3_test_02/./work_PR2_UQ_c                     (0 files differ)            
mww3_test_02/./work_PR3_UQ_b                     (0 files differ)            
mww3_test_02/./work_PR3_UQ_a                     (0 files differ)            
mww3_test_02/./work_PR1_a                     (0 files differ)               
mww3_test_02/./work_PR3_UNO_MPI_d                     (0 files differ)       
mww3_test_02/./work_PR3_UNO_a_c                     (0 files differ)         
mww3_test_02/./work_PR2_UQ_MPI_b                     (0 files differ)        
mww3_test_02/./work_PR3_UNO_d                     (0 files differ)           
mww3_test_02/./work_PR3_UNO_MPI_c_c                     (0 files differ)     
mww3_test_02/./work_PR3_UNO_MPI_a_c                     (0 files differ)     
mww3_test_02/./work_PR2_UQ_a                     (0 files differ)            
mww3_test_02/./work_PR3_UNO_MPI_b                     (0 files differ)       
mww3_test_02/./work_PR3_UNO_b_c                     (0 files differ)         
mww3_test_02/./work_PR1_b                     (0 files differ)               
mww3_test_02/./work_PR2_UNO_b                     (0 files differ)           
mww3_test_02/./work_PR3_UQ_MPI_c_c                     (0 files differ)      
mww3_test_02/./work_PR2_UQ_d                     (0 files differ)            
mww3_test_02/./work_PR3_UQ_c                     (0 files differ)            
mww3_test_02/./work_PR3_UNO_MPI_a                     (0 files differ)       
mww3_test_02/./work_PR1_MPI_c                     (0 files differ)           
mww3_test_02/./work_PR3_UNO_b                     (0 files differ)           
mww3_test_02/./work_PR1_MPI_b                     (0 files differ)           
mww3_test_02/./work_PR3_UQ_a_c                     (0 files differ)          
mww3_test_02/./work_PR3_UQ_MPI_b_c                     (0 files differ)      
mww3_test_02/./work_PR3_UQ_d_c                     (0 files differ)          
mww3_test_02/./work_PR1_MPI_a                     (0 files differ)           
mww3_test_02/./work_PR3_UQ_MPI_d_c                     (0 files differ)      
mww3_test_02/./work_PR3_UQ_MPI_d                     (0 files differ)        
mww3_test_02/./work_PR3_UQ_d                     (0 files differ)            
mww3_test_02/./work_PR3_UNO_d_c                     (0 files differ)         
mww3_test_02/./work_PR3_UQ_c_c                     (0 files differ)          
mww3_test_02/./work_PR2_UNO_MPI_b                     (0 files differ)       
mww3_test_02/./work_PR3_UNO_MPI_c                     (0 files differ)       
mww3_test_02/./work_PR2_UQ_b                     (0 files differ)            
mww3_test_02/./work_PR3_UNO_c                     (0 files differ)           
mww3_test_02/./work_PR3_UNO_a                     (0 files differ)           
mww3_test_02/./work_PR2_UQ_MPI_d                     (0 files differ)        
mww3_test_02/./work_PR2_UQ_MPI_c                     (0 files differ)        
mww3_test_02/./work_PR2_UNO_a                     (0 files differ)           
mww3_test_02/./work_PR2_UNO_MPI_c                     (0 files differ)       
mww3_test_02/./work_PR2_UNO_MPI_a                     (0 files differ)       
mww3_test_02/./work_PR3_UQ_b_c                     (0 files differ)          
mww3_test_02/./work_PR3_UQ_MPI_b                     (0 files differ)        
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)           
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)      
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)        
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)       
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)     
mww3_test_03/./work_PR1_MPI_d2                     (6 files differ)          
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)   
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)    
mww3_test_03/./work_PR3_UNO_MPI_d2                     (15 files differ)     
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)      
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)     
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
ww3_ta1/./work_UPD0F_O                     (0 files differ)                  
ww3_ta1/./work_UPD0F_U                     (0 files differ)                  
ww3_ta1/./work_UPD2_U_cap                     (0 files differ)               
ww3_ta1/./work_UPD3_U                     (0 files differ)                   
ww3_ta1/./work_UPD5_U_cap                     (0 files differ)               
ww3_ta1/./work_UPD6_O                     (0 files differ)                   
ww3_ta1/./work_UPD2_U                     (0 files differ)                   
ww3_ta1/./work_UPD5_O                     (0 files differ)                   
ww3_ta1/./work_UPD5_U                     (0 files differ)                   
ww3_ta1/./work_UPD3_U_cap                     (0 files differ)               
ww3_ta1/./work_UPD3_O                     (0 files differ)                   
ww3_ta1/./work_UPD6_U                     (0 files differ)                   
ww3_ta1/./work_UPD2_O                     (0 files differ)                   
ww3_ta1/./work_UPD6_U_cap                     (0 files differ)               
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)              
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)              
ww3_tp2.17/./work_ma                     (1 files differ)                    
ww3_tp2.17/./work_a                     (1 files differ)                     
ww3_tp2.17/./work_mc1                     (1 files differ)                   
ww3_tp2.17/./work_mb                     (1 files differ)                    
ww3_tp2.17/./work_mc                     (1 files differ)                    
ww3_tp2.17/./work_ma1                     (1 files differ)                   
ww3_tp2.17/./work_c                     (1 files differ)                     
ww3_tp2.17/./work_b                     (1 files differ)                     
ww3_ufs1.3/./work_a                     (3 files differ)                                                                                  
**********************************************************************       
************************ identical cases *****************************       
**********************************************************************
```

* [hera.matrixCompFull.txt](https://github.com/erdc/WW3/files/10844632/hera.matrixCompFull.txt)
* [hera.matrixDiff.txt](https://github.com/erdc/WW3/files/10844633/hera.matrixDiff.txt)
* [hera.matrixCompSummary.txt](https://github.com/erdc/WW3/files/10844634/hera.matrixCompSummary.txt)

