### PR TITLE
feature_brcoeff: slope-dependant breaking coefficient

### DIFF
--- a/model/src/pdlib_field_vec.F90
+++ b/model/src/pdlib_field_vec.F90
@@ -830,7 +830,7 @@ CONTAINS
          STH2M, HSIG, TAUICE, PHICE, PTHP0, PQP,&
          PPE, PGW, PSW, PTM1, PT1, PT2, PEP,   &
          QP, MSSD, MSCD, STMAXE, STMAXD, HMAXE, &
-         HCMAXE, HMAXD, HCMAXD, WBT, USSP
+         HCMAXE, HMAXD, HCMAXD, WBT, USSP, BRCOEF
     USE W3GDATMD, ONLY: NK, NSEAL
     USE W3ODATMD, ONLY: NDST, IAPROC, NAPROC, NTPROC, FLOUT,   &
          NAPFLD, NAPPNT, NAPRST, NAPBPT, NAPTRK,&
@@ -967,6 +967,10 @@ CONTAINS
           IF ( FLGRDALL( 2, 19) ) THEN
             IH = IH + 1
             Arrexch(IH,JSEA)=WNMEAN(JSEA)
+		  END IF
+          IF ( FLGRDALL( 2, 20) ) THEN
+            IH = IH + 1
+            Arrexch(IH,JSEA)=BRCOEF(JSEA)
           END IF
           IF ( FLGRDALL( 3, 1) ) THEN
             DO IK=E3DF(2,1),E3DF(3,1)
@@ -1410,6 +1414,10 @@ CONTAINS
         IF ( FLGRDALL( 2, 19) ) THEN
           IH = IH + 1
           WNMEAN(1:NSEA) = ARRtotal(IH,:)
+        END IF
+        IF ( FLGRDALL( 2, 20) ) THEN
+          IH = IH + 1
+          BRCOEF(1:NSEA) = ARRtotal(IH,:)
         END IF
         IF ( FLGRDALL( 3, 1) ) THEN
           DO IK=E3DF(2,1),E3DF(3,1)

--- a/model/src/pdlib_field_vec.F90
+++ b/model/src/pdlib_field_vec.F90
@@ -169,6 +169,9 @@ CONTAINS
     IF ( FLGRDALL( 2, 19) ) THEN
       IH = IH + 1
     END IF
+    IF ( FLGRDALL( 2, 20) ) THEN
+      IH =IH + 1
+    END IF
     IF ( FLGRDALL( 3, 1) ) THEN
       DO IK=E3DF(2,1),E3DF(3,1)
         IH = IH + 1
@@ -967,7 +970,7 @@ CONTAINS
           IF ( FLGRDALL( 2, 19) ) THEN
             IH = IH + 1
             Arrexch(IH,JSEA)=WNMEAN(JSEA)
-		  END IF
+          END IF
           IF ( FLGRDALL( 2, 20) ) THEN
             IH = IH + 1
             Arrexch(IH,JSEA)=BRCOEF(JSEA)

--- a/model/src/w3adatmd.F90
+++ b/model/src/w3adatmd.F90
@@ -407,14 +407,15 @@ MODULE W3ADATMD
          THS(:),  THP0(:),                   &
          HSIG(:), STMAXE(:), STMAXD(:),      &
          HMAXE(:), HCMAXE(:), HMAXD(:),      &
-         HCMAXD(:), QP(:), WBT(:), WNMEAN(:)
+         HCMAXD(:), QP(:), WBT(:), WNMEAN(:),&
+         BRCOEF(:)
     REAL, POINTER         :: XHS(:), XWLM(:), XT02(:), XT0M1(:),  &
          XT01 (:), XFP0(:), XTHM(:),          &
          XTHS(:), XTHP0(:),                   &
          XHSIG(:), XSTMAXE(:), XSTMAXD(:),    &
          XHMAXE(:), XHCMAXE(:), XHMAXD(:),    &
          XHCMAXD(:), XQP(:), XWBT(:),         &
-         XWNMEAN(:)
+         XWNMEAN(:), XBRCOEF(:)
     !
     ! Output fields group 3)
     !
@@ -589,7 +590,7 @@ MODULE W3ADATMD
        THP0(:), HSIG(:),                    &
        STMAXE(:), STMAXD(:), HMAXE(:),      &
        HCMAXE(:), HMAXD(:), HCMAXD(:),      &
-       QP(:), WBT(:), WNMEAN(:)
+       QP(:), WBT(:), WNMEAN(:), BRCOEF(:)
   !
   REAL, POINTER           :: EF(:,:), TH1M(:,:), STH1M(:,:),      &
        TH2M(:,:), STH2M(:,:)
@@ -1050,6 +1051,7 @@ CONTAINS
          WADATS(IMOD)%HCMAXD(NSEALM), WADATS(IMOD)%QP(NSEALM),      &
          WADATS(IMOD)%WBT(NSEALM),                                  &
          WADATS(IMOD)%WNMEAN(NSEALM),                               &
+         WADATS(IMOD)%BRCOEF(NSEALM),                               &
          STAT=ISTAT )
     CHECK_ALLOC_STATUS ( ISTAT )
     !
@@ -1072,6 +1074,7 @@ CONTAINS
     WADATS(IMOD)%QP     = UNDEF
     WADATS(IMOD)%WBT    = UNDEF
     WADATS(IMOD)%WNMEAN = UNDEF
+    WADATS(IMOD)%BRCOEF = UNDEF
 
     call print_memcheck(memunit, 'memcheck_____:'//' W3DIMA 3')
     !
@@ -1733,6 +1736,14 @@ CONTAINS
       CHECK_ALLOC_STATUS ( ISTAT )
     END IF
     !
+    IF ( OUTFLAGS( 2, 20) ) THEN
+      ALLOCATE ( WADATS(IMOD)%XBRCOEF(NXXX), STAT=ISTAT )
+      CHECK_ALLOC_STATUS ( ISTAT )
+    ELSE
+      ALLOCATE ( WADATS(IMOD)%XBRCOEF(1), STAT=ISTAT )
+      CHECK_ALLOC_STATUS ( ISTAT )
+    END IF
+    !
     WADATS(IMOD)%XHS    = UNDEF
     WADATS(IMOD)%XWLM   = UNDEF
     WADATS(IMOD)%XT02   = UNDEF
@@ -1751,6 +1762,7 @@ CONTAINS
     WADATS(IMOD)%XHCMAXD= UNDEF
     WADATS(IMOD)%XWBT   = UNDEF
     WADATS(IMOD)%XWNMEAN= UNDEF
+    WADATS(IMOD)%XBRCOEF= UNDEF
     !
     IF ( OUTFLAGS( 3, 1) ) THEN
       ALLOCATE ( WADATS(IMOD)%XEF(NXXX,E3DF(2,1):E3DF(3,1)), STAT=ISTAT )
@@ -2860,6 +2872,7 @@ CONTAINS
       QP     => WADATS(IMOD)%QP
       WBT    => WADATS(IMOD)%WBT
       WNMEAN => WADATS(IMOD)%WNMEAN
+      BRCOEF => WADATS(IMOD)%BRCOEF
       !
       EF     => WADATS(IMOD)%EF
       TH1M   => WADATS(IMOD)%TH1M
@@ -3203,6 +3216,7 @@ CONTAINS
       QP     => WADATS(IMOD)%XQP
       WBT    => WADATS(IMOD)%XWBT
       WNMEAN => WADATS(IMOD)%XWNMEAN
+      BRCOEF => WADATS(IMOD)%XBRCOEF
       !
       EF     => WADATS(IMOD)%XEF
       TH1M   => WADATS(IMOD)%XTH1M

--- a/model/src/w3gdatmd.F90
+++ b/model/src/w3gdatmd.F90
@@ -528,6 +528,9 @@ MODULE W3GDATMD
   !      SDBC2     Real  Public   Hmax/d ratio.                (!/DB1)
   !      FDONLY    Log.  Public   Flag for checking depth only (!/DB1)
   !                               otherwise Miche criterion.
+  !      FSLOPE    Log.  Public   Flag for computing slope     (!/DB1)       
+  !                               dependant breaking coeff,
+  !                               constant otherwise
   !     ----------------------------------------------------------------
   !
   !     The structure STRP contains parameters for the triad interaction
@@ -989,7 +992,7 @@ MODULE W3GDATMD
 #endif
 #ifdef W3_DB1
     REAL                  :: SDBC1, SDBC2
-    LOGICAL               :: FDONLY
+    LOGICAL               :: FDONLY, FSLOPE
     REAL                  :: SDBSC
 #endif
   END TYPE SDBP
@@ -1391,7 +1394,7 @@ MODULE W3GDATMD
   !/
 #ifdef W3_DB1
   REAL, POINTER           :: SDBC1, SDBC2
-  LOGICAL, POINTER        :: FDONLY
+  LOGICAL, POINTER        :: FDONLY, FSLOPE
   REAL, POINTER           :: SDBSC
 #endif
   !/
@@ -2814,6 +2817,7 @@ CONTAINS
     SDBC1  => MPARS(IMOD)%SDBPS%SDBC1
     SDBC2  => MPARS(IMOD)%SDBPS%SDBC2
     FDONLY => MPARS(IMOD)%SDBPS%FDONLY
+    FSLOPE => MPARS(IMOD)%SDBPS%FSLOPE
     SDBSC  => MPARS(IMOD)%SDBPS%SDBSC
 #endif
     !

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -896,6 +896,7 @@ MODULE W3GRIDMD
 #ifdef W3_DB1
   REAL                    :: BJALFA, BJGAM
   LOGICAL                 :: BJFLAG
+  LOGICAL                 :: BRFLAG
 #endif
 #ifdef W3_PR2
   REAL                    :: DTIME
@@ -1066,7 +1067,7 @@ MODULE W3GRIDMD
        BOTROUGHMIN, BOTROUGHFAC
 #endif
 #ifdef W3_DB1
-  NAMELIST /SDB1/ BJALFA, BJGAM, BJFLAG
+  NAMELIST /SDB1/ BJALFA, BJGAM, BJFLAG, BRFLAG
 #endif
 #ifdef W3_UOST
   NAMELIST /UOST/ UOSTFILELOCAL, UOSTFILESHADOW,             &
@@ -2358,11 +2359,20 @@ CONTAINS
     BJALFA = 1.
     BJGAM  = 0.73
     BJFLAG = .TRUE.
+    BRFLAG = .FALSE.
     CALL READNL ( NDSS, 'SDB1', STATUS )
-    WRITE (NDSO,928) STATUS
-    BJALFA = MAX ( 0. , BJALFA )
-    BJGAM  = MAX ( 0. , BJGAM )
-    WRITE (NDSO,929) BJALFA, BJGAM
+	WRITE (NDSO,928) STATUS
+    IF ( BRFLAG ) THEN
+      WRITE (NDSO,*) '      Slope-dependant breaking coeff.'
+      BJALFA = MIN (50. , MAX ( 40. , BJALFA ))
+      BJGAM  = MAX ( 0. , BJGAM )
+      WRITE (NDSO,929) BJALFA, BJGAM
+    ELSE
+      WRITE (NDSO,*) '      Constant breaking coeff.'
+      BJALFA = MAX ( 0. , BJALFA )
+      BJGAM  = MAX ( 0. , BJGAM )
+      WRITE (NDSO,929) BJALFA, BJGAM
+    END IF
     IF ( BJFLAG ) THEN
       WRITE (NDSO,*) '      Using Hmax/d ratio only.'
     ELSE
@@ -2373,6 +2383,7 @@ CONTAINS
     SDBC1  = BJALFA
     SDBC2  = BJGAM
     FDONLY = BJFLAG
+    FSLOPE = BRFLAG
 #endif
     !
     !
@@ -3314,9 +3325,17 @@ CONTAINS
 #endif
 #ifdef W3_DB1
       IF ( BJFLAG ) THEN
-        WRITE (NDSO,2928) BJALFA, BJGAM, '.TRUE.'
+        IF (BRFLAG) THEN
+          WRITE (NDSO,2928) BJALFA, BJGAM, '.TRUE.', '.TRUE.'
+		ELSE
+          WRITE (NDSO,2928) BJALFA, BJGAM, '.TRUE.', '.FALSE.'
+        END IF
       ELSE
-        WRITE (NDSO,2928) BJALFA, BJGAM, '.FALSE.'
+        IF (BRFLAG) THEN
+          WRITE (NDSO,2928) BJALFA, BJGAM, '.FALSE.', '.TRUE.'
+		ELSE
+          WRITE (NDSO,2928) BJALFA, BJGAM, '.FALSE.', '.FALSE.'
+		END IF
       END IF
 #endif
 #ifdef W3_PR1
@@ -6514,10 +6533,10 @@ CONTAINS
 #ifdef W3_DB1
 928 FORMAT (/'  Surf breaking (B&J 1978) ',A/                  &
          ' --------------------------------------------------')
-929 FORMAT ( '       alpha                       :',F8.3/      &
+929 FORMAT ( '       alpha / slope factor                       :',F8.3/      &
          '       gamma                       :',F8.3)
 2928 FORMAT ( '  &SDB1 BJALFA =',F7.3,', BJGAM =',F7.3,         &
-         ', BJFLAG = ',A,' /')
+         ', BJFLAG = ',A,', BRFLAG = ' ,A,' /')
 #endif
     !
 #ifdef W3_TR0

--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -2150,7 +2150,8 @@ CONTAINS
          STMAXE, STMAXD, HMAXE, HCMAXE, HMAXD,     &
          HCMAXD, QP, PTHP0, PQP, PPE, PGW, PSW,    &
          PTM1, PT1, PT2, PEP, WBT, CX, CY,         &
-         TAUOCX, TAUOCY, WNMEAN, QKK, SKEW, EMBIA1, EMBIA2
+         TAUOCX, TAUOCY, WNMEAN, QKK, SKEW,        & 
+         EMBIA1, EMBIA2, BRCOEF
 #endif
 
 #ifdef W3_MPI
@@ -2464,6 +2465,16 @@ CONTAINS
                IT, MPI_COMM_WAVE, IRQGO(IH), IERR)
 #ifdef W3_MPIT
           WRITE (NDST,9011) IH, ' 2/19', IROOT, IT, IRQGO(IH), IERR
+#endif
+        END IF
+        !
+        IF ( FLGRDALL( 2, 20) ) THEN
+          IH     = IH + 1
+          IT     = IT + 1
+          CALL MPI_SEND_INIT (BRCOEF(1),NSEALM , MPI_REAL, IROOT,   &
+               IT, MPI_COMM_WAVE, IRQGO(IH), IERR)
+#ifdef W3_MPIT
+          WRITE (NDST,9011) IH, ' 2/20', IROOT, IT, IRQGO(IH), IERR
 #endif
         END IF
         !
@@ -3534,6 +3545,16 @@ CONTAINS
                  MPI_COMM_WAVE, IRQGO2(IH), IERR )
 #ifdef W3_MPIT
             WRITE (NDST,9011) IH, ' 2/19', IFROM, IT, IRQGO2(IH), IERR
+#endif
+          END IF
+          !
+          IF ( FLGRDALL( 2, 20) ) THEN
+            IH     = IH + 1
+            IT     = IT + 1
+            CALL MPI_RECV_INIT (BRCOEF(I0),1,WW3_FIELD_VEC, IFROM, IT, &
+                 MPI_COMM_WAVE, IRQGO2(IH), IERR )
+#ifdef W3_MPIT
+            WRITE (NDST,9011) IH, ' 2/20', IFROM, IT, IRQGO2(IH), IERR
 #endif
           END IF
           !

--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -912,10 +912,13 @@ CONTAINS
     CASE('WNM')
       I = 2
       J = 19
+    CASE('BRCOEF')
+      I = 2
+      J = 20
 #ifdef W3_OASOCM
     CASE('THM')
       I = 2
-      J = 20
+      J = 21
 #endif
       !
       ! Group 3
@@ -2517,7 +2520,7 @@ CONTAINS
     USE W3ADATMD, ONLY: AINIT, DW, UA, UD, AS, CX, CY, WN,          &
          TAUA, TAUADIR
     USE W3ADATMD, ONLY: HS, WLM, T02, T0M1, T01, FP0, THM, THS, THP0,&
-         WBT, WNMEAN
+         WBT, WNMEAN, BRCOEF
     USE W3ADATMD, ONLY: DTDYN, FCUT, ABA, ABD, UBA, UBD, SXX, SYY, SXY,&
          PHS, PTP, PLP, PDIR, PSI, PWS, PWST, PNR,    &
          PTHP0, PQP, PPE, PGW, PSW, PTM1, PT1, PT2,  &
@@ -2841,6 +2844,7 @@ CONTAINS
           IF ( FLOGRD( 2,16) ) HCMAXD(ISEA) = UNDEF
           IF ( FLOGRD( 2,17) ) WBT   (ISEA) = UNDEF
           IF ( FLOGRD( 2,19) ) WNMEAN(ISEA) = UNDEF
+          IF ( FLOGRD( 2,20) ) BRCOEF(ISEA) = UNDEF
           !
           IF ( FLOGRD( 3, 1) ) EF   (ISEA,:) = UNDEF
           IF ( FLOGRD( 3, 2) ) TH1M (ISEA,:) = UNDEF
@@ -3210,6 +3214,11 @@ CONTAINS
               WRITE ( NDSOG ) WNMEAN(1:NSEA)
 #ifdef W3_ASCII
               WRITE ( NDSOA,* ) 'WNMEAN:', WNMEAN(1:NSEA)
+#endif
+            ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 20 ) THEN
+              WRITE ( NDSOG ) BRCOEF(1:NSEA)
+#ifdef W3_ASCII
+              WRITE ( NDSOA,* ) 'BRCOEF:', BRCOEF(1:NSEA)
 #endif
               !
               !     Section 3)
@@ -3779,6 +3788,9 @@ CONTAINS
             ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 19 ) THEN
               READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
                    WNMEAN(1:NSEA)
+            ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 20 ) THEN
+              READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
+                   BRCOEF(1:NSEA)
               !
               !     Section 3)
               !

--- a/model/src/w3iogrmd.F90
+++ b/model/src/w3iogrmd.F90
@@ -1809,18 +1809,18 @@ CONTAINS
 #ifdef W3_DB1
     IF ( WRITE ) THEN
       WRITE (NDSM)                                            &
-           SDBC1, SDBC2, FDONLY
+           SDBC1, SDBC2, FDONLY, FSLOPE
 #ifdef W3_ASCII
       WRITE (NDSA,*)                                          &
-           'SDBC1, SDBC2, FDONLY:',                           &
-           SDBC1, SDBC2, FDONLY
+           'SDBC1, SDBC2, FDONLY, FSLOPE:',                   &
+           SDBC1, SDBC2, FDONLY, FSLOPE
 #endif
     ELSE
       READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                 &
-           SDBC1, SDBC2, FDONLY
+           SDBC1, SDBC2, FDONLY, FSLOPE
     END IF
     !
-    IF ( FLTEST ) WRITE (NDST,9053) SDBC1, SDBC2, FDONLY
+    IF ( FLTEST ) WRITE (NDST,9053) SDBC1, SDBC2, FDONLY, FSLOPE
 #endif
 
 #ifdef W3_UOST

--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -321,7 +321,7 @@ MODULE W3ODATMD
   INTEGER                 :: NOUTP = -1, IOUTP = -1, IOSTYP = 1
   !
   INTEGER, PARAMETER      :: NOGRP = 10
-  INTEGER, PARAMETER      :: NGRPP = 20
+  INTEGER, PARAMETER      :: NGRPP = 21
   INTEGER, PARAMETER      :: DIMP = 15
   INTEGER                 :: NOGE(NOGRP)
   INTEGER                 :: NOTYPE

--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -770,9 +770,9 @@ CONTAINS
     !
     ! 2) Standard mean wave parameters
     !
-    NOGE(2) = 19
-#ifdef W3_OASOCM
     NOGE(2) = 20
+#ifdef W3_OASOCM
+    NOGE(2) = 21
 #endif
     !
     IDOUT( 2, 1)  = 'Wave height         '
@@ -794,8 +794,9 @@ CONTAINS
     IDOUT( 2, 17)  = 'Dominant wave bT   '
     IDOUT( 2, 18)  = 'Peak prd. (from fp)'
     IDOUT( 2, 19)  = 'Mean wave number   '
+    IDOUT( 2, 20)  = 'Breaking coef.     '
 #ifdef W3_OASOCM
-    IDOUT( 2, 20) = 'Mean wave dir. norot'
+    IDOUT( 2, 21) = 'Mean wave dir. norot'
 #endif
     !      IDOUT( 2,10)  = 'Mean wave dir. a2b2'
     !      IDOUT( 2,11)  = 'Mean dir. spr. a2b2'

--- a/model/src/w3ounfmetamd.F90
+++ b/model/src/w3ounfmetamd.F90
@@ -2972,6 +2972,17 @@ CONTAINS
     META(1)%VARNG=''
     META(1)%VMIN = 0
     META(1)%VMAX = 32
+    ! IFI=2, IFJ=20
+    META => GROUP(2)%FIELD(20)%META
+    META(1)%FSC    = 0.001
+    META(1)%UNITS  = '1'
+    META(1)%ENAME  = '.brc'
+    META(1)%VARNM='brcoef'
+    META(1)%VARNL='breaking coefficient'
+    META(1)%VARNS=''
+    META(1)%VARNG=''
+    META(1)%VMIN = 0
+    META(1)%VMAX = 1.2
     !
     !---------- GROUP 3 ----------------
     !

--- a/model/src/w3sdb1md.F90
+++ b/model/src/w3sdb1md.F90
@@ -128,6 +128,8 @@ CONTAINS
     !
     !     Where CDB   = SDBC1 = BJALFA (defaults to BJALFA = 1)
     !                   modified via ww3_grid namelist parameter BJALFA
+    !                 = BRCOEF if FSLOPE=T
+    !                   modified via ww3_grid namelist parameter BRFLAG
     !           HM    = GAMMA * DEP
     !           GAMMA = SDBC2 defaults to 0.73 (mean Battjes/Janssen value)
     !                   modified via ww3_grid namelist parameter BJGAM
@@ -183,7 +185,8 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/
     USE CONSTANTS
-    USE W3GDATMD, ONLY: NK, NTH, NSPEC, SDBC1, SDBC2, FDONLY, FSSOURCE, DDEN
+    USE W3ADATMD, ONLY: BRCOEF
+    USE W3GDATMD, ONLY: NK, NTH, NSPEC, SDBC1, SDBC2, FDONLY, FSLOPE, FSSOURCE, DDEN
     USE W3ODATMD, ONLY: NDST
     USE W3GDATMD, ONLY: SIG
     USE W3ODATMD, only : IAPROC
@@ -220,6 +223,7 @@ CONTAINS
     REAL*8                    :: HM, BB, ARG, Q0, QB, B, CBJ, HRMS, EB(NK)
     REAL*8                    :: AUX, CBJ2, RATIO, S0, S1, THR, BR1, BR2, FAK
     REAL                      :: ETOT, FMEAN2
+    REAL                      :: BRCOEF_LOC
 #ifdef W3_T0
     REAL                    :: DOUT(NK,NTH)
 #endif
@@ -312,15 +316,23 @@ CONTAINS
       QB = 1.0 - THR
     END IF
     !
-    ! 3. Estimate the breaking coefficient ------------------------------- /
+    ! 3. Breaking coefficient
+    !
+	  IF (FSLOPE) THEN
+      BRCOEF_LOC = MAX(0.1,MIN(BRCOEF(IX),1.2))
+	  ELSE
+	    BRCOEF_LOC = DBLE(SDBC1)
+	  END IF
+    !
+    ! 4. Estimate the breaking coefficient ------------------------------- /
     !
     CBJ  = 0
     IF (IWB == 1) THEN
       IF ( ( BB .GT. THR) .AND. ( ABS ( BB - QB ) .GT. THR) ) THEN
         IF ( BB .LT. 1.0) THEN
-          CBJ = 2 * DBLE(SDBC1) * QB * DBLE(FMEAN) / BB
+          CBJ = 2 * BRCOEF_LOC * QB * DBLE(FMEAN) / BB
         ELSE
-          CBJ = 2 * DBLE(SDBC1) * DBLE(FMEAN) * BB ! AR: degenerative regime, all waves must be .le. Hmax, we just smoothly let the excessive energy vanish by * BB.
+          CBJ = 2 * BRCOEF_LOC * DBLE(FMEAN) * BB ! AR: degenerative regime, all waves must be .le. Hmax, we just smoothly let the excessive energy vanish by * BB.
         END IF
       ELSE
         CBJ = 0.d0
@@ -331,7 +343,7 @@ CONTAINS
       IF (ETOT .GT. THR) THEN
         HRMS = SQRT(8*EMEAN)
         FAK  = (1+4./SQRT(PI)*(B*BB+1.5*B)*exp(-BB)-ERF(B))
-        CBJ  = -SDBC1*SQRT(PI)/16.*FMEAN*HRMS**3/DEPTH/ETOT
+        CBJ  = -BRCOEF_LOC*SQRT(PI)/16.*FMEAN*HRMS**3/DEPTH/ETOT
       ELSE
         CBJ  = 0.
       ENDIF
@@ -347,8 +359,8 @@ CONTAINS
 
 #ifdef W3_DEBUGRUN
     IF (IX == DEBUG_NODE) THEN
-      WRITE(*,'(A200)') 'IX, DEPTH, CBJ, BB, QB, SDBC1, SDBC2, FMEAN, FMEAN2, HS'
-      WRITE(*,'(I10,20F20.10)') IX, DEPTH, CBJ, BB, QB, SDBC1, SDBC2, FMEAN, FMEAN2, 4*SQRT(ETOT)
+      WRITE(*,'(A200)') 'IX, DEPTH, CBJ, BB, QB, BRCOEF_LOC SDBC1, SDBC2, FMEAN, FMEAN2, HS'
+      WRITE(*,'(I10,20F20.10)') IX, DEPTH, CBJ, BB, QB, BRCOEF_LOC, SDBC1, SDBC2, FMEAN, FMEAN2, 4*SQRT(ETOT)
     ENDIF
 #endif
     !

--- a/model/src/w3sdb1md.F90
+++ b/model/src/w3sdb1md.F90
@@ -318,11 +318,11 @@ CONTAINS
     !
     ! 3. Breaking coefficient
     !
-	  IF (FSLOPE) THEN
-      BRCOEF_LOC = MAX(0.1,MIN(BRCOEF(IX),1.2))
-	  ELSE
-	    BRCOEF_LOC = DBLE(SDBC1)
-	  END IF
+    IF (FSLOPE) THEN
+      BRCOEF_LOC = BRCOEF(IX)
+    ELSE
+      BRCOEF_LOC = DBLE(SDBC1)
+    END IF
     !
     ! 4. Estimate the breaking coefficient ------------------------------- /
     !

--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -1282,7 +1282,7 @@ CONTAINS
       IF (.NOT. FSSOURCE .or. LSLOC) THEN
 #endif
 #ifdef W3_DB1
-        CALL W3SDB1 ( IX, SPEC, DEPTH, EMEAN, FMEAN, WNMEAN, CG1,       &
+        CALL W3SDB1 ( JSEA, SPEC, DEPTH, EMEAN, FMEAN, WNMEAN, CG1,       &
              LBREAK, VSDB, VDDB )
 #endif
 #ifdef W3_PDLIB

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1451,23 +1451,6 @@ CONTAINS
         END IF
 #endif
         call print_memcheck(memunit, 'memcheck_____:'//' WW3_WAVE TIME LOOP 13')
-        !
-		    ! Compute slope-dependant depth-induced breaking coefficient
-		    !
-		    CALL W3OUTG ( VA, .FALSE., .FALSE., .FALSE. )
-		    DO JSEA=1, NSEAL
-		      CALL INIT_GET_ISEA(ISEA, JSEA)
-		      IX     = MAPSF(ISEA,1)
-		      IY     = MAPSF(ISEA,2)
-		      IF (LPDLIB) THEN
-			      TANBETA = -DDDX(1,JSEA)*COS(THM(JSEA)) - DDDY(1,JSEA)*SIN(THM(JSEA))
-			      BRCOEF(JSEA) = MAX(0.1,MIN(DBLE(SDBC1)*TANBETA,1.2))
-		      ELSE
-			      TANBETA = -DDDX(IY,IX)*COS(THM(JSEA)) - DDDY(IY,IX)*SIN(THM(JSEA))
-			      BRCOEF(JSEA) = MAX(0.1,MIN(DBLE(SDBC1)*TANBETA,1.2))
-		      ENDIF
-	      END DO
-        !
 #ifdef W3_PDLIB
         IF (LPDLIB .and. FLSOU .and. FSSOURCE) THEN
 #endif
@@ -1495,7 +1478,6 @@ CONTAINS
 
 
 #ifdef W3_PDLIB
-
           DO JSEA = 1, NP
 
             CALL INIT_GET_ISEA(ISEA, JSEA)
@@ -1688,7 +1670,23 @@ CONTAINS
           END IF
         END IF
 #endif
-
+#ifdef W3_DB1
+        !
+        ! Compute slope-dependant depth-induced breaking coefficient
+        !
+        CALL W3OUTG ( VA, .FALSE., .FALSE., .FALSE. )
+        DO JSEA=1, NSEAL
+          CALL INIT_GET_ISEA(ISEA, JSEA)
+          IX     = MAPSF(ISEA,1)
+          IY     = MAPSF(ISEA,2)
+          IF (LPDLIB) THEN
+            TANBETA = -DDDX(1,JSEA)*COS(THM(JSEA)) - DDDY(1,JSEA)*SIN(THM(JSEA))
+          ELSE
+            TANBETA = -DDDX(IY,IX)*COS(THM(JSEA)) - DDDY(IY,IX)*SIN(THM(JSEA))
+          END IF
+          BRCOEF(JSEA) = MAX(0.1,MIN(DBLE(SDBC1)*TANBETA,1.2))
+        END DO
+#endif
         !
         ! 3.6 Perform Propagation = = = = = = = = = = = = = = = = = = = = = = =
         ! 3.6.1 Preparations

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -543,7 +543,7 @@ CONTAINS
          DTGA, DTG, DTGpre, DTRES,            &
          FAC, VGX, VGY, FACK, FACTH,          &
          FACX, XXX, REFLEC(4),                &
-         DELX, DELY, DELA, DEPTH, D50, PSIC
+         DELX, DELY, DELA, DEPTH, D50, PSIC, TANBETA
     REAL                     :: VSioDummy(NSPEC), VDioDummy(NSPEC), VAoldDummy(NSPEC)
     LOGICAL                  :: SHAVETOTioDummy
 #ifdef W3_SEC1
@@ -1451,6 +1451,22 @@ CONTAINS
         END IF
 #endif
         call print_memcheck(memunit, 'memcheck_____:'//' WW3_WAVE TIME LOOP 13')
+        !
+		    ! Compute slope-dependant depth-induced breaking coefficient
+		    !
+		    CALL W3OUTG ( VA, .FALSE., .FALSE., .FALSE. )
+		    DO JSEA=1, NSEAL
+		      CALL INIT_GET_ISEA(ISEA, JSEA)
+		      IX     = MAPSF(ISEA,1)
+		      IY     = MAPSF(ISEA,2)
+		      IF (LPDLIB) THEN
+			      TANBETA = -DDDX(1,JSEA)*COS(THM(JSEA)) - DDDY(1,JSEA)*SIN(THM(JSEA))
+			      BRCOEF(JSEA) = MAX(0.1,MIN(DBLE(SDBC1)*TANBETA,1.2))
+		      ELSE
+			      TANBETA = -DDDX(IY,IX)*COS(THM(JSEA)) - DDDY(IY,IX)*SIN(THM(JSEA))
+			      BRCOEF(JSEA) = MAX(0.1,MIN(DBLE(SDBC1)*TANBETA,1.2))
+		      ENDIF
+	      END DO
         !
 #ifdef W3_PDLIB
         IF (LPDLIB .and. FLSOU .and. FSSOURCE) THEN

--- a/model/src/ww3_gint.F90
+++ b/model/src/ww3_gint.F90
@@ -1093,7 +1093,7 @@ CONTAINS
          FP0AUX, THMAUX1, THMAUX2, THSAUX, THP0AUX1,   &
          THP0AUX2, HSIGAUX, STMAXEAUX,STMAXDAUX,       &
          HMAXEAUX, HCMAXEAUX, HMAXDAUX, HCMAXDAUX,     &
-         WBTAUX, WNMEANAUX, SUMWT2(NOGE(2))
+         WBTAUX, WNMEANAUX, BRCOEFAUX, SUMWT2(NOGE(2))
     ! Local group 3 variables
     REAL          :: EFAUX(E3DF(2,1):E3DF(3,1)),                   &
          TH1MAUX(E3DF(2,2):E3DF(3,2)),                 &
@@ -1198,6 +1198,7 @@ CONTAINS
     HCMAXD   = UNDEF
     WBT      = UNDEF
     WNMEAN   = UNDEF
+    BRCOEF   = UNDEF 
     !
     ! Group 3 variables
     !
@@ -1434,6 +1435,7 @@ CONTAINS
             HCMAXDAUX   = UNDEF
             WBTAUX      = UNDEF
             WNMEANAUX   = UNDEF
+            BRCOEFAUX   = UNDEF
             SUMWT2      = 0
             !
             ! Group 3 variables
@@ -1885,6 +1887,14 @@ CONTAINS
                   SUMWT2(19) = SUMWT2(19) + WT
                   IF ( WNMEANAUX .EQ. UNDEF )   WNMEANAUX = 0.
                   WNMEANAUX = WNMEANAUX + WADATS(IGRID)%WNMEAN(GSEA)*WT
+                END IF
+              END IF
+              !
+              IF ( FLOGRD(2,20) .AND. ACTIVE ) THEN
+                IF ( WADATS(IGRID)%BRCOEF(GSEA) .NE. UNDEF ) THEN
+                  SUMWT2(20) = SUMWT2(20) + WT
+                  IF ( BRCOEFAUX .EQ. UNDEF )   BRCOEFAUX = 0.
+                  BRCOEFAUX = BRCOEFAUX + WADATS(IGRID)%BRCOEF(GSEA)*WT
                 END IF
               END IF
               !
@@ -2827,6 +2837,12 @@ CONTAINS
               IF ( WNMEAN(ISEA) .EQ. UNDEF )   WNMEAN(ISEA) = 0.
               WNMEAN(ISEA) = WNMEAN(ISEA) +                      &
                    WNMEANAUX / REAL( SUMWT2(19)*SUMGRD )
+            END IF
+            !
+            IF ( BRCOEFAUX .NE. UNDEF ) THEN
+              IF ( BRCOEF(ISEA) .EQ. UNDEF )   BRCOEF(ISEA) = 0.
+              BRCOEF(ISEA) = BRCOEF(ISEA) +                      &
+                   BRCOEFAUX / REAL( SUMWT2(20)*SUMGRD )
             END IF
             !
             ! Group 3 variables

--- a/model/src/ww3_ounf.F90
+++ b/model/src/ww3_ounf.F90
@@ -194,7 +194,8 @@ PROGRAM W3OUNF
        CFLTHMAX, CFLXYMAX, CFLKMAX, TAUICE, PHICE,  &
        STMAXE, STMAXD, HMAXE, HCMAXE, HMAXD, HCMAXD,&
        P2SMS, EF, US3D, TH1M, STH1M, TH2M, STH2M,   &
-       WN, USSP, WBT, WNMEAN, QKK, SKEW, EMBIA1, EMBIA2
+       WN, USSP, WBT, WNMEAN, QKK, SKEW, EMBIA1,    &
+       EMBIA2, BRCOEF
   USE W3ODATMD, ONLY: NDSO, NDSE, SCREEN, NOGRP, NGRPP, IDOUT,     &
        UNDEF, FLOGRD, FNMPRE, NOSWLL, NOGE
   !
@@ -1403,6 +1404,10 @@ CONTAINS
             ELSE
               CALL W3S2XY ( NSEA, NSEA, NX+1, NY, WNMEAN, MAPSF, X1 )
             END IF
+            !
+            ! Breaking coefficient
+          ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 20 ) THEN
+              CALL S2GRID(BRCOEF, X1)
             !
             ! Wave elevation spectrum
           ELSE IF ( IFI .EQ. 3 .AND. IFJ .EQ. 1 ) THEN

--- a/model/src/ww3_outf.F90
+++ b/model/src/ww3_outf.F90
@@ -168,7 +168,7 @@ PROGRAM W3OUTF
        CFLTHMAX, CFLKMAX, BEDFORMS, WHITECAP, T02, &
        CGE, T01, HSIG, STMAXE, STMAXD, HMAXE,      &
        HCMAXE, HMAXD, HCMAXD, MSSD, MSCD, WBT,     &
-       WNMEAN, TAUA, TAUADIR
+       WNMEAN, TAUA, TAUADIR, BRCOEF
   USE W3ODATMD, ONLY: NDSO, NDSE, NDST, NOGRP, NGRPP, IDOUT,      &
        UNDEF, FLOGRD, FNMPRE, NOSWLL, NOGE
   !
@@ -1254,6 +1254,16 @@ CONTAINS
               CALL W3S2XY ( NSEA, NSEA, NX+1, NY, WNMEAN, MAPSF, X1)
             ENDIF
             !
+          ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 20 ) THEN
+            FLONE  = .TRUE.
+            FSC    = 0.001
+            UNITS  = '1'
+            ENAME  = '.br'
+            IF ( ITYPE .EQ. 4 ) THEN
+              XS1    = BRCOEF
+            ELSE
+              CALL W3S2XY ( NSEA, NSEA, NX+1, NY, BRCOEF, MAPSF, X1)
+            ENDIF
           ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 1 ) THEN
             FLONE  = .TRUE.
             FSC    = 0.01


### PR DESCRIPTION
# Pull Request Summary
Computes a slope-dependant breaking coefficient for the depth-induced breaking source term

## Description
Computes a slope-dependant breaking coefficient (BRCOEF) for the depth-induced breaking source term. A new flag (BRFLAG) is added to SDB1 namelist to choose between a constant breaking coefficient (BRFLAG=F, default value) prescribed with BJALFA parameter (same as before) or the adapting breaking coeff. (BRFLAG=T). In such case, the slope coefficient can be slightly adapted by the user through BJALFA parameter (default value 40).
Several studies demonstrate the robustness of this parameterization already implemented in the spectral wave model WWM (e.g. see Pezerat et al, 2021, OM), which allows to prevent an over dissipation by depth-induced breaking, especially in dissipative surf zone. 
Please also include the following information: 
* Add any suggestions for a reviewer: Aron Roland, Ali Abdolali
* Mention any labels that should be added:  _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply:  _out_grd change_

### Issue(s) addressed

None


### Commit Message

Slope dependant breaking coefficient. 


### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? This new feature has been tested on regtest tp18 (Haas and Warner) and personnal configuration using unstructured grid.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

